### PR TITLE
Fix typed reference for globe component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import Globe from 'react-globe.gl'
 import type { GlobeMethods } from 'react-globe.gl'
 
 function App() {
-  const globeEl = useRef<GlobeMethods | undefined>(undefined)
+  // use a null default value so the ref type matches React's expectations
+  const globeEl = useRef<GlobeMethods | null>(null)
 
   useEffect(() => {
     globeEl.current?.pointOfView({ lat: 0, lng: 0, altitude: 2 }, 0)


### PR DESCRIPTION
## Summary
- ensure `useRef` ref type matches React expectations

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react' and others)*