### PR TITLE
Cleanup gitignore logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,6 @@ Thumbs.db
 .ipynb_checkpoints
 
 # Logs
-*.log
-
-# Logs
 logs
 *.log
 npm-debug.log*


### PR DESCRIPTION
## Summary
- remove duplicate `# Logs` section from `.gitignore`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*