### PR TITLE
Add Vitest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -27,6 +28,8 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import App from './App'
+
+vi.mock('react-globe.gl', () => {
+  return {
+    __esModule: true,
+    default: React.forwardRef((props: any, ref) => (
+      <div ref={ref} data-testid="globe" {...props} />
+    )),
+  }
+})
+
+describe('App', () => {
+  it('renders Globe element', () => {
+    render(<App />)
+    expect(screen.getByTestId('globe')).toBeTruthy()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary
- add `vitest` and `@testing-library/react` dev deps
- configure Vite for jsdom-based unit tests
- create a basic `<App>` test
- expose `npm test` script

## Testing
- `npx vitest run` *(fails: unable to fetch packages)*