### PR TITLE
Add satellite orbit propagation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -15,7 +15,17 @@ vi.mock('react-globe.gl', () => {
 beforeEach(() => {
   vi.stubGlobal('fetch', vi.fn(() =>
     Promise.resolve({
-      text: () => Promise.resolve(''),
+      text: () =>
+        Promise.resolve(
+          [
+            'semi_major_axis = 6771',
+            'eccentricity = 0.0001',
+            'inclination = 98.7',
+            'raan = 257.7',
+            'argument_of_perigee = 130.5',
+            'mean_anomaly = 45.0',
+          ].join('\n'),
+        ),
     })
   ))
 })
@@ -36,8 +46,10 @@ describe('App', () => {
     expect(Array.isArray(globeEl.pointsData)).toBe(true)
     expect(globeEl.pointsData.length).toBe(1)
     const firstLng = globeEl.pointsData[0].lng
+    const firstLat = globeEl.pointsData[0].lat
     vi.advanceTimersByTime(1000)
     expect(globeEl.pointsData[0].lng).not.toBe(firstLng)
+    expect(globeEl.pointsData[0].lat).toBeCloseTo(firstLat, 1)
     vi.useRealTimers()
   })
 })

--- a/src/orbit.ts
+++ b/src/orbit.ts
@@ -1,0 +1,49 @@
+export interface OrbitElements {
+  semi_major_axis: number
+  eccentricity: number
+  inclination: number
+  raan: number
+  argument_of_perigee: number
+  mean_anomaly: number
+}
+
+const MU = 398600.4418 // km^3/s^2
+
+function solveKepler(M: number, e: number): number {
+  let E = M
+  for (let i = 0; i < 15; i++) {
+    const dE = (E - e * Math.sin(E) - M) / (1 - e * Math.cos(E))
+    E -= dE
+    if (Math.abs(dE) < 1e-8) break
+  }
+  return E
+}
+
+export function propagateOrbit(el: OrbitElements, tSec: number) {
+  const n = Math.sqrt(MU / Math.pow(el.semi_major_axis, 3))
+  const M0 = (el.mean_anomaly * Math.PI) / 180
+  const M = M0 + n * tSec
+  const E = solveKepler(M, el.eccentricity)
+
+  const cosE = Math.cos(E)
+  const sinE = Math.sin(E)
+  const sqrtOneMinusE2 = Math.sqrt(1 - el.eccentricity * el.eccentricity)
+
+  const xOrb = el.semi_major_axis * (cosE - el.eccentricity)
+  const yOrb = el.semi_major_axis * sqrtOneMinusE2 * sinE
+
+  const cosO = Math.cos((el.raan * Math.PI) / 180)
+  const sinO = Math.sin((el.raan * Math.PI) / 180)
+  const cosI = Math.cos((el.inclination * Math.PI) / 180)
+  const sinI = Math.sin((el.inclination * Math.PI) / 180)
+  const cosW = Math.cos((el.argument_of_perigee * Math.PI) / 180)
+  const sinW = Math.sin((el.argument_of_perigee * Math.PI) / 180)
+
+  const x = (cosO * cosW - sinO * sinW * cosI) * xOrb +
+            (-cosO * sinW - sinO * cosW * cosI) * yOrb
+  const y = (sinO * cosW + cosO * sinW * cosI) * xOrb +
+            (-sinO * sinW + cosO * cosW * cosI) * yOrb
+  const z = (sinW * sinI) * xOrb + (cosW * sinI) * yOrb
+
+  return { x, y, z }
+}


### PR DESCRIPTION
## Summary
- read orbital elements from `public/satellite.toml`
- compute ECI position from elements with a small propagator
- convert to lat/lon/alt and update Globe points
- adjust tests to stub the TOML data

## Testing
- `npm test` *(fails: `vitest` not found)*