### PR TITLE
Fix timestamp placement for mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,19 @@ function App() {
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
       <div ref={mountRef} style={{ width: "100%", height: "100%" }} />
-      <div ref={timeRef} style={{ position: "absolute", right: 8, bottom: 6, color: "#fff", fontFamily: "'Noto Sans Mono', monospace", fontVariantNumeric: "tabular-nums", fontSize: "0.9rem", pointerEvents: "none" }} />
+      <div
+        ref={timeRef}
+        style={{
+          position: "fixed",
+          right: 8,
+          bottom: 6,
+          color: "#fff",
+          fontFamily: "'Noto Sans Mono', monospace",
+          fontVariantNumeric: "tabular-nums",
+          fontSize: "0.9rem",
+          pointerEvents: "none",
+        }}
+      />
       <SpeedControl value={speedExp} onChange={setSpeedExp} />
     </div>
   );


### PR DESCRIPTION
## Summary
- keep timestamp fixed to the viewport so it is visible on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*