### PR TITLE
Show UTC/JST time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ A minimal web application to visualize Earth and satellites in orbit in real tim
 ## Features
 
 - Render a 3D Earth with realistic texture and graticule lines.
+- Correct texture orientation to match longitude lines.
 - Visualize satellite positions and ground tracks from TLE data.
 - Adjustable simulation speed (1×–100× real time) via slider.
 - Interactive orbit controls for zooming, rotating, and panning.
-- Display current simulated UTC date and time.
+- Display current simulated UTC and JST date and time.
 - Responsive viewport that adjusts on window resize.
 
 ## Prerequisites

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ function App() {
           fontFamily: "'Noto Sans Mono', monospace",
           fontVariantNumeric: "tabular-nums",
           fontSize: "0.9rem",
+          whiteSpace: "pre",
           pointerEvents: "none",
           zIndex: 10,
         }}

--- a/src/hooks/useSatelliteScene.ts
+++ b/src/hooks/useSatelliteScene.ts
@@ -3,10 +3,15 @@ import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import * as satellite from "satellite.js";
 import { SATELLITES, toSatrec } from "../satellites";
-import { sunVectorECI, createGraticule, createEclipticLine } from "../utils/sceneHelpers";
+import {
+  sunVectorECI,
+  createGraticule,
+  createEclipticLine,
+  greenwichSiderealAngle,
+} from "../utils/sceneHelpers";
 
 const EARTH_RADIUS_KM = 6371;
-const SIDEREAL_DAY_SEC = 86164;
+const TEXTURE_ROTATION = Math.PI; // adjust for map orientation
 
 interface Params {
   mountRef: React.RefObject<HTMLDivElement | null>;
@@ -43,6 +48,8 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
 
     const earthGeometry = new THREE.SphereGeometry(1, 128, 128);
     const texture = new THREE.TextureLoader().load("/assets/earth_daymap.jpg");
+    texture.center.set(0.5, 0.5);
+    texture.rotation = TEXTURE_ROTATION;
     const earthMaterial = new THREE.MeshPhongMaterial({ map: texture, shininess: 1 });
     const earthMesh = new THREE.Mesh(earthGeometry, earthMaterial);
     scene.add(earthMesh);
@@ -71,8 +78,16 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
 
     const startReal = Date.now();
     const pad = (n: number) => n.toString().padStart(2, "0");
-    const fmt = (d: Date) =>
-      `${d.getFullYear()}年${pad(d.getMonth() + 1)}月${pad(d.getDate())}日${pad(d.getHours())}時${pad(d.getMinutes())}分`;
+    const fmtUtc = (d: Date) =>
+      `UTC: ${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ` +
+      `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+    const fmtJst = (d: Date) => {
+      const jst = new Date(d.getTime() + 9 * 3600 * 1000);
+      return (
+        `JST: ${jst.getUTCFullYear()}-${pad(jst.getUTCMonth() + 1)}-${pad(jst.getUTCDate())} ` +
+        `${pad(jst.getUTCHours())}:${pad(jst.getUTCMinutes())}`
+      );
+    };
 
     function animate() {
       requestAnimationFrame(animate);
@@ -80,9 +95,9 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
       const simDeltaMs = (nowReal - startReal) * speedRef.current;
       const simDate = new Date(startReal + simDeltaMs);
 
-      const rotAngle = ((2 * Math.PI) / SIDEREAL_DAY_SEC) * (simDeltaMs / 1000);
-      earthMesh.rotation.y = rotAngle;
-      graticule.rotation.y = rotAngle;
+      const gst = greenwichSiderealAngle(simDate);
+      earthMesh.rotation.y = gst;
+      graticule.rotation.y = gst;
 
       const sun = sunVectorECI(simDate);
       sunlight.position.set(sun.x * 10, sun.z * 10, -sun.y * 10);
@@ -102,7 +117,8 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
         }
       });
 
-      if (timeRef.current) timeRef.current.textContent = fmt(simDate);
+      if (timeRef.current)
+        timeRef.current.textContent = `${fmtUtc(simDate)}\n${fmtJst(simDate)}`;
 
       controls.update();
       renderer.render(scene, camera);

--- a/src/utils/sceneHelpers.ts
+++ b/src/utils/sceneHelpers.ts
@@ -3,6 +3,25 @@ import * as satellite from "satellite.js";
 
 const DEG2RAD = Math.PI / 180;
 
+export function greenwichSiderealAngle(date: Date): number {
+  const jd = satellite.jday(
+    date.getUTCFullYear(),
+    date.getUTCMonth() + 1,
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds() + date.getUTCMilliseconds() / 1000,
+  );
+  const T = (jd - 2451545.0) / 36525.0;
+  let gmst =
+    280.46061837 +
+    360.98564736629 * (jd - 2451545.0) +
+    0.000387933 * T * T -
+    (T * T * T) / 38710000;
+  gmst = ((gmst % 360) + 360) % 360;
+  return gmst * DEG2RAD;
+}
+
 export function sunVectorECI(date: Date): { x: number; y: number; z: number } {
   const jd = satellite.jday(
     date.getUTCFullYear(),


### PR DESCRIPTION
## Summary
- display times in both UTC and JST
- keep time label readable with `whiteSpace: pre`
- document change in README
- ensure Earth texture lines up with longitude lines
- rotate Earth using Greenwich sidereal time

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*