### PR TITLE
Add in-browser satellite editing

### DIFF
--- a/scripts/generate-satellites.ts
+++ b/scripts/generate-satellites.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const satText = await Bun.file("public/satellites.toml").text();
 const { satellites: rawSats } = Bun.TOML.parse(satText) as { satellites: any[] };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { useRef, useEffect, useState } from "react";
 import SpeedControl from "./components/SpeedControl";
+import SatelliteEditor from "./components/SatelliteEditor";
 import { useSatelliteScene } from "./hooks/useSatelliteScene";
+import { SATELLITES as INITIAL_SATS } from "./satellites";
 
 const INITIAL_SPEED = 60; // initial 60× real time
 
 function App() {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const timeRef = useRef<HTMLDivElement | null>(null);
+
+  const [satellites, setSatellites] = useState(INITIAL_SATS);
 
   // speed exponent slider (0–2 → 1×–100×)
   const [speedExp, setSpeedExp] = useState(Math.log10(INITIAL_SPEED));
@@ -15,7 +19,7 @@ function App() {
     speedRef.current = Math.pow(10, speedExp);
   }, [speedExp]);
 
-  useSatelliteScene({ mountRef, timeRef, speedRef });
+  useSatelliteScene({ mountRef, timeRef, speedRef, satellites });
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -37,6 +41,7 @@ function App() {
         }}
       />
       <SpeedControl value={speedExp} onChange={setSpeedExp} />
+      <SatelliteEditor onUpdate={setSatellites} />
     </div>
   );
 }

--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import type { SatelliteSpec } from "../satellites";
+import { parseSatellitesToml, parseConstellationToml } from "../utils/tomlParse";
+
+interface Props {
+  onUpdate: (sats: SatelliteSpec[]) => void;
+}
+
+export default function SatelliteEditor({ onUpdate }: Props) {
+  const [satText, setSatText] = useState("");
+  const [constText, setConstText] = useState("");
+
+  useEffect(() => {
+    fetch("/satellites.toml")
+      .then((r) => r.text())
+      .then(setSatText);
+    fetch("/constellation.toml")
+      .then((r) => r.text())
+      .then(setConstText)
+      .catch(() => setConstText(""));
+  }, []);
+
+  const handleUpdate = () => {
+    try {
+      const base = parseSatellitesToml(satText);
+      const con = constText ? parseConstellationToml(constText) : [];
+      onUpdate([...base, ...con]);
+    } catch (e) {
+      alert("Failed to parse files: " + (e as Error).message);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 8,
+        top: 8,
+        background: "rgba(0,0,0,0.6)",
+        color: "#fff",
+        padding: 8,
+        fontFamily: "monospace",
+        zIndex: 20,
+        maxWidth: 300,
+      }}
+    >
+      <div>
+        <div>satellites.toml</div>
+        <textarea
+          value={satText}
+          onChange={(e) => setSatText(e.target.value)}
+          style={{ width: "100%", height: 80 }}
+        />
+      </div>
+      <div style={{ marginTop: 4 }}>
+        <div>constellation.toml</div>
+        <textarea
+          value={constText}
+          onChange={(e) => setConstText(e.target.value)}
+          style={{ width: "100%", height: 80 }}
+        />
+      </div>
+      <button onClick={handleUpdate} style={{ marginTop: 4 }}>
+        Update
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useSatelliteScene.ts
+++ b/src/hooks/useSatelliteScene.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import * as satellite from "satellite.js";
-import { SATELLITES, toSatrec } from "../satellites";
+import { toSatrec, SatelliteSpec } from "../satellites";
 import { sunVectorECI, createGraticule, createEclipticLine } from "../utils/sceneHelpers";
 
 const EARTH_RADIUS_KM = 6371;
@@ -12,9 +12,10 @@ interface Params {
   mountRef: React.RefObject<HTMLDivElement | null>;
   timeRef: React.RefObject<HTMLDivElement | null>;
   speedRef: React.MutableRefObject<number>;
+  satellites: SatelliteSpec[];
 }
 
-export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
+export function useSatelliteScene({ mountRef, timeRef, speedRef, satellites }: Params) {
   useEffect(() => {
     if (!mountRef.current) return;
     const mountNode = mountRef.current;
@@ -63,7 +64,7 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
     const groundGeo = new THREE.SphereGeometry(0.005, 8, 8);
     const groundMat = new THREE.MeshBasicMaterial({ color: 0xa9a9a9 });
 
-    const satRecs = SATELLITES.map((spec) => toSatrec(spec));
+    const satRecs = satellites.map((spec) => toSatrec(spec));
     const satMeshes = satRecs.map(() => new THREE.Mesh(satGeo, satMat));
     const groundMeshes = satRecs.map(() => new THREE.Mesh(groundGeo, groundMat));
     satMeshes.forEach((m) => scene.add(m));
@@ -108,8 +109,6 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
         }
       });
 
-      debugger;
-      console.log(satRecs);
 
       if (timeRef.current) timeRef.current.textContent = fmt(simDate);
 
@@ -133,5 +132,5 @@ export function useSatelliteScene({ mountRef, timeRef, speedRef }: Params) {
         mountNode.removeChild(renderer.domElement);
       }
     };
-  }, [mountRef, timeRef, speedRef]);
+  }, [mountRef, timeRef, speedRef, satellites]);
 }

--- a/src/utils/tomlParse.ts
+++ b/src/utils/tomlParse.ts
@@ -1,0 +1,127 @@
+// Utility to parse minimal TOML used for satellites and constellations
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { SatelliteSpec } from "../satellites";
+
+function parseValue(v: string): any {
+  const s = v.trim();
+  if (s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
+  if (s.startsWith("'") && s.endsWith("'")) return s.slice(1, -1);
+  if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/.test(s)) return new Date(s.replace(/['"]/g, ""));
+  const n = Number(s);
+  if (!Number.isNaN(n)) return n;
+  return s;
+}
+
+export function parseSatellitesToml(text: string): SatelliteSpec[] {
+  const lines = text.split(/\r?\n/);
+  const result: any[] = [];
+  let current: Record<string, any> | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line === '[[satellites]]') {
+      if (current) result.push(current);
+      current = {};
+      continue;
+    }
+    const m = line.match(/^([A-Za-z0-9_]+)\s*=\s*(.+)$/);
+    if (m && current) {
+      current[m[1]] = parseValue(m[2]);
+    }
+  }
+  if (current) result.push(current);
+
+  return result.map((s) => {
+    if (s.type === 'tle') {
+      return { type: 'tle', lines: [String(s.line1 || ''), String(s.line2 || '')] } as SatelliteSpec;
+    }
+    if (s.type === 'elements') {
+      return {
+        type: 'elements',
+        elements: {
+          satnum: Number(s.satnum),
+          epoch: new Date(String(s.epoch)),
+          semiMajorAxisKm: Number(s.semiMajorAxisKm),
+          eccentricity: Number(s.eccentricity),
+          inclinationDeg: Number(s.inclinationDeg),
+          raanDeg: Number(s.raanDeg),
+          argPerigeeDeg: Number(s.argPerigeeDeg),
+          meanAnomalyDeg: Number(s.meanAnomalyDeg),
+        },
+      } as SatelliteSpec;
+    }
+    throw new Error('Unknown satellite type');
+  });
+}
+
+const EARTH_RADIUS_KM = 6371;
+
+function generateFromShells(con: any): SatelliteSpec[] {
+  const epoch = new Date(String(con.epoch));
+  let nextSatnum = 10000;
+  const sats: SatelliteSpec[] = [];
+  for (const shell of con.shells ?? []) {
+    const count = Number(shell.count);
+    const planes = Number(shell.planes);
+    const perPlane = Math.ceil(count / planes);
+    const phasing = Number(shell.phasing ?? 0);
+    const ecc = Number(shell.eccentricity ?? 0);
+    const inc = Number(shell.inclination ?? 0);
+    const aAltitude = Number(shell.apogee_altitude ?? 0);
+    const raanRange = Number(shell.raan_range ?? 360);
+    const raanStart = Number(shell.raan_start ?? 0);
+    const argp = Number(shell.argp ?? 0);
+    const m0 = Number(shell.mean_anomaly_0 ?? 0);
+    const semiMajorAxisKm = EARTH_RADIUS_KM + aAltitude;
+
+    for (let p = 0; p < planes; p++) {
+      const raan = raanStart + (raanRange * p) / planes;
+      for (let j = 0; j < perPlane && sats.length < count; j++) {
+        const ma = (m0 + (360 / count) * (p * phasing + j * planes)) % 360;
+        sats.push({
+          type: 'elements',
+          elements: {
+            satnum: nextSatnum++,
+            epoch,
+            semiMajorAxisKm,
+            eccentricity: ecc,
+            inclinationDeg: inc,
+            raanDeg: raan,
+            argPerigeeDeg: argp,
+            meanAnomalyDeg: ma,
+          },
+        });
+      }
+    }
+  }
+  return sats;
+}
+
+export function parseConstellationToml(text: string): SatelliteSpec[] {
+  const lines = text.split(/\r?\n/);
+  const con: any = { shells: [] };
+  let current: Record<string, any> | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line === '[constellation]') {
+      continue;
+    }
+    if (line === '[[constellation.shells]]') {
+      if (current) con.shells.push(current);
+      current = {};
+      continue;
+    }
+    const m = line.match(/^([A-Za-z0-9_]+)\s*=\s*(.+)$/);
+    if (m) {
+      const val = parseValue(m[2]);
+      if (current) {
+        current[m[1]] = val;
+      } else {
+        con[m[1]] = val;
+      }
+    }
+  }
+  if (current) con.shells.push(current);
+  return generateFromShells(con);
+}


### PR DESCRIPTION
## Summary
- create `SatelliteEditor` component to edit satellites and constellation data
- load and parse TOML files in the browser
- inject updated satellite list into the scene
- expose editor in `App` and pass satellites to `useSatelliteScene`
- update `useSatelliteScene` to accept dynamic satellite list
- disable `no-explicit-any` lints in helper utilities and script

## Testing
- `npm run lint`