### PR TITLE
Add slide-out satellite editor

### DIFF
--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -9,6 +9,7 @@ interface Props {
 export default function SatelliteEditor({ onUpdate }: Props) {
   const [satText, setSatText] = useState("");
   const [constText, setConstText] = useState("");
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     fetch("/satellites.toml")
@@ -31,38 +32,77 @@ export default function SatelliteEditor({ onUpdate }: Props) {
   };
 
   return (
-    <div
-      style={{
-        position: "absolute",
-        left: 8,
-        top: 8,
-        background: "rgba(0,0,0,0.6)",
-        color: "#fff",
-        padding: 8,
-        fontFamily: "monospace",
-        zIndex: 20,
-        maxWidth: 300,
-      }}
-    >
-      <div>
-        <div>satellites.toml</div>
-        <textarea
-          value={satText}
-          onChange={(e) => setSatText(e.target.value)}
-          style={{ width: "100%", height: 80 }}
-        />
+    <>
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            position: "absolute",
+            left: 8,
+            top: 8,
+            background: "rgba(0,0,0,0.6)",
+            color: "#fff",
+            border: "none",
+            padding: "4px 8px",
+            fontSize: "1.2rem",
+            zIndex: 30,
+          }}
+        >
+          ☰
+        </button>
+      )}
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          height: "100%",
+          width: 300,
+          maxWidth: "80%",
+          background: "rgba(0,0,0,0.6)",
+          color: "#fff",
+          padding: 8,
+          fontFamily: "monospace",
+          zIndex: 20,
+          transform: open ? "translateX(0)" : "translateX(-100%)",
+          transition: "transform 0.3s ease-out",
+          boxSizing: "border-box",
+        }}
+      >
+        <button
+          onClick={() => setOpen(false)}
+          style={{
+            position: "absolute",
+            right: 8,
+            top: 8,
+            background: "transparent",
+            border: "none",
+            color: "#fff",
+            fontSize: "1.2rem",
+          }}
+        >
+          ✕
+        </button>
+        <div style={{ paddingTop: 24 }}>
+          <div>satellites.toml</div>
+          <textarea
+            value={satText}
+            onChange={(e) => setSatText(e.target.value)}
+            style={{ width: "100%", height: 80 }}
+          />
+        </div>
+        <div style={{ marginTop: 4 }}>
+          <div>constellation.toml</div>
+          <textarea
+            value={constText}
+            onChange={(e) => setConstText(e.target.value)}
+            style={{ width: "100%", height: 80 }}
+          />
+        </div>
+        <button onClick={handleUpdate} style={{ marginTop: 4 }}>
+          Update
+        </button>
       </div>
-      <div style={{ marginTop: 4 }}>
-        <div>constellation.toml</div>
-        <textarea
-          value={constText}
-          onChange={(e) => setConstText(e.target.value)}
-          style={{ width: "100%", height: 80 }}
-        />
-      </div>
-      <button onClick={handleUpdate} style={{ marginTop: 4 }}>
-        Update
-      </button>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- replace in-place satellite editor with slide-out sidebar
- add hamburger button to reveal editor

## Testing
- `npm run lint`
- `npm run build`
