### PR TITLE
Add ground station visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A web application to visualize Earth and satellites in orbit using React, TypeSc
 
 - Render a 3D Earth.
 - Visualize satellite positions.
+- Show visibility of satellites from a ground station in Tokyo.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- calculate ground station position (Tokyo)
- detect when satellites rise above 10 degrees elevation
- draw white link lines and color satellites green when visible
- document the new feature in the README

## Testing
- `bun run lint`
- `bun run build`
