### PR TITLE
Support multiple ground stations via TOML

### DIFF
--- a/public/groundstations.toml
+++ b/public/groundstations.toml
@@ -1,0 +1,13 @@
+[[groundstations]]
+name = "Tokyo"
+latitudeDeg = 35.6895
+longitudeDeg = 139.6917
+heightKm = 0
+minElevationDeg = 10
+
+[[groundstations]]
+name = "Sydney"
+latitudeDeg = -33.8688
+longitudeDeg = 151.2093
+heightKm = 0
+minElevationDeg = 5

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import SpeedControl from "./components/SpeedControl";
 import SatelliteEditor from "./components/SatelliteEditor";
 import { useSatelliteScene } from "./hooks/useSatelliteScene";
 import { SATELLITES as INITIAL_SATS } from "./satellites";
+import { loadGroundStations, type GroundStation } from "./groundStations";
 
 const INITIAL_SPEED = 60; // initial 60× real time
 
@@ -11,6 +12,7 @@ function App() {
   const timeRef = useRef<HTMLDivElement | null>(null);
 
   const [satellites, setSatellites] = useState(INITIAL_SATS);
+  const [groundStations, setGroundStations] = useState<GroundStation[]>([]);
 
   // speed exponent slider (0–2 → 1×–100×)
   const [speedExp, setSpeedExp] = useState(Math.log10(INITIAL_SPEED));
@@ -18,8 +20,11 @@ function App() {
   useEffect(() => {
     speedRef.current = Math.pow(10, speedExp);
   }, [speedExp]);
+  useEffect(() => {
+    loadGroundStations().then(setGroundStations);
+  }, []);
 
-  useSatelliteScene({ mountRef, timeRef, speedRef, satellites });
+  useSatelliteScene({ mountRef, timeRef, speedRef, satellites, groundStations });
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -41,7 +46,7 @@ function App() {
         }}
       />
       <SpeedControl value={speedExp} onChange={setSpeedExp} />
-      <SatelliteEditor onUpdate={setSatellites} />
+      <SatelliteEditor onUpdate={(s, gs) => { setSatellites(s); setGroundStations(gs); }} />
     </div>
   );
 }

--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState } from "react";
 import type { SatelliteSpec } from "../satellites";
-import { parseSatellitesToml, parseConstellationToml } from "../utils/tomlParse";
+import type { GroundStation } from "../groundStations";
+import {
+  parseSatellitesToml,
+  parseConstellationToml,
+  parseGroundStationsToml,
+} from "../utils/tomlParse";
 
 interface Props {
-  onUpdate: (sats: SatelliteSpec[]) => void;
+  onUpdate: (sats: SatelliteSpec[], stations: GroundStation[]) => void;
 }
 
 export default function SatelliteEditor({ onUpdate }: Props) {
   const [satText, setSatText] = useState("");
   const [constText, setConstText] = useState("");
+  const [gsText, setGsText] = useState("");
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -19,13 +25,18 @@ export default function SatelliteEditor({ onUpdate }: Props) {
       .then((r) => r.text())
       .then(setConstText)
       .catch(() => setConstText(""));
+    fetch("/groundstations.toml")
+      .then((r) => r.text())
+      .then(setGsText)
+      .catch(() => setGsText(""));
   }, []);
 
   const handleUpdate = () => {
     try {
       const base = parseSatellitesToml(satText);
       const con = constText ? parseConstellationToml(constText) : [];
-      onUpdate([...base, ...con]);
+      const gs = parseGroundStationsToml(gsText);
+      onUpdate([...base, ...con], gs);
     } catch (e) {
       alert("Failed to parse files: " + (e as Error).message);
     }
@@ -96,6 +107,14 @@ export default function SatelliteEditor({ onUpdate }: Props) {
           <textarea
             value={constText}
             onChange={(e) => setConstText(e.target.value)}
+            style={{ width: "100%", height: 80 }}
+          />
+        </div>
+        <div style={{ marginTop: 4 }}>
+          <div>groundstations.toml</div>
+          <textarea
+            value={gsText}
+            onChange={(e) => setGsText(e.target.value)}
             style={{ width: "100%", height: 80 }}
           />
         </div>

--- a/src/groundStations.ts
+++ b/src/groundStations.ts
@@ -1,0 +1,9 @@
+import { parseGroundStationsToml, type GroundStation } from './utils/tomlParse';
+
+export async function loadGroundStations(): Promise<GroundStation[]> {
+  const resp = await fetch('/groundstations.toml');
+  const text = await resp.text();
+  return parseGroundStationsToml(text);
+}
+
+export type { GroundStation };

--- a/src/utils/tomlParse.ts
+++ b/src/utils/tomlParse.ts
@@ -125,3 +125,39 @@ export function parseConstellationToml(text: string): SatelliteSpec[] {
   if (current) con.shells.push(current);
   return generateFromShells(con);
 }
+
+export interface GroundStation {
+  name: string;
+  latitudeDeg: number;
+  longitudeDeg: number;
+  heightKm: number;
+  minElevationDeg: number;
+}
+
+export function parseGroundStationsToml(text: string): GroundStation[] {
+  const lines = text.split(/\r?\n/);
+  const result: any[] = [];
+  let current: Record<string, any> | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line === '[[groundstations]]') {
+      if (current) result.push(current);
+      current = {};
+      continue;
+    }
+    const m = line.match(/^([A-Za-z0-9_]+)\s*=\s*(.+)$/);
+    if (m && current) {
+      current[m[1]] = parseValue(m[2]);
+    }
+  }
+  if (current) result.push(current);
+
+  return result.map((gs) => ({
+    name: String(gs.name ?? ''),
+    latitudeDeg: Number(gs.latitudeDeg),
+    longitudeDeg: Number(gs.longitudeDeg),
+    heightKm: Number(gs.heightKm ?? 0),
+    minElevationDeg: Number(gs.minElevationDeg ?? 0),
+  }));
+}


### PR DESCRIPTION
## Summary
- load ground station data from new `groundstations.toml`
- parse ground station definitions in `tomlParse`
- manage ground stations in app state and sidebar editor
- render and link satellites to multiple ground stations

## Testing
- `npm run build`
- `npm run lint`
