### PR TITLE
Add sidebar control for simulation start time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,9 @@ function App() {
   const [satellites, setSatellites] = useState(INITIAL_SATS);
   const [groundStations, setGroundStations] = useState<GroundStation[]>([]);
 
+  // simulation start time (ms since epoch)
+  const [startTimeMs, setStartTimeMs] = useState(Date.now());
+
   // speed exponent slider (0–2 → 1×–100×)
   const [speedExp, setSpeedExp] = useState(Math.log10(INITIAL_SPEED));
   const speedRef = useRef(INITIAL_SPEED);
@@ -24,7 +27,14 @@ function App() {
     loadGroundStations().then(setGroundStations);
   }, []);
 
-  useSatelliteScene({ mountRef, timeRef, speedRef, satellites, groundStations });
+  useSatelliteScene({
+    mountRef,
+    timeRef,
+    speedRef,
+    startTimeMs,
+    satellites,
+    groundStations,
+  });
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -46,7 +56,14 @@ function App() {
         }}
       />
       <SpeedControl value={speedExp} onChange={setSpeedExp} />
-      <SatelliteEditor onUpdate={(s, gs) => { setSatellites(s); setGroundStations(gs); }} />
+      <SatelliteEditor
+        startTime={new Date(startTimeMs)}
+        onStartTimeChange={(d) => setStartTimeMs(d.getTime())}
+        onUpdate={(s, gs) => {
+          setSatellites(s);
+          setGroundStations(gs);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useState } from "react";
+
+const pad = (n: number) => n.toString().padStart(2, "0");
+const formatForInput = (d: Date) =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 import type { SatelliteSpec } from "../satellites";
 import type { GroundStation } from "../groundStations";
 import {
@@ -9,13 +13,20 @@ import {
 
 interface Props {
   onUpdate: (sats: SatelliteSpec[], stations: GroundStation[]) => void;
+  startTime: Date;
+  onStartTimeChange: (date: Date) => void;
 }
 
-export default function SatelliteEditor({ onUpdate }: Props) {
+export default function SatelliteEditor({ onUpdate, startTime, onStartTimeChange }: Props) {
   const [satText, setSatText] = useState("");
   const [constText, setConstText] = useState("");
   const [gsText, setGsText] = useState("");
   const [open, setOpen] = useState(false);
+  const [startStr, setStartStr] = useState(formatForInput(startTime));
+
+  useEffect(() => {
+    setStartStr(formatForInput(startTime));
+  }, [startTime]);
 
   useEffect(() => {
     fetch("/satellites.toml")
@@ -94,6 +105,25 @@ export default function SatelliteEditor({ onUpdate }: Props) {
         >
           ✕
         </button>
+        <div style={{ paddingTop: 24 }}>
+          <div>Start time (local)</div>
+          <div style={{ display: "flex", gap: 4 }}>
+            <input
+              type="datetime-local"
+              value={startStr}
+              onChange={(e) => setStartStr(e.target.value)}
+              style={{ width: "100%" }}
+            />
+            <button
+              onClick={() => {
+                const d = new Date(startStr);
+                if (!isNaN(d.getTime())) onStartTimeChange(d);
+              }}
+            >
+              Set
+            </button>
+          </div>
+        </div>
         <div style={{ paddingTop: 24 }}>
           <div>satellites.toml</div>
           <textarea

--- a/src/hooks/useSatelliteScene.ts
+++ b/src/hooks/useSatelliteScene.ts
@@ -18,6 +18,7 @@ interface Params {
   mountRef: React.RefObject<HTMLDivElement | null>;
   timeRef: React.RefObject<HTMLDivElement | null>;
   speedRef: React.MutableRefObject<number>;
+  startTimeMs: number;
   satellites: SatelliteSpec[];
   groundStations: GroundStation[];
 }
@@ -31,6 +32,7 @@ export function useSatelliteScene({
   mountRef,
   timeRef,
   speedRef,
+  startTimeMs,
   satellites,
   groundStations,
 }: Params) {
@@ -148,7 +150,7 @@ export function useSatelliteScene({
       requestAnimationFrame(animate);
       const nowReal = Date.now();
       const simDeltaMs = (nowReal - startReal) * speedRef.current;
-      const simDate = new Date(startReal + simDeltaMs);
+      const simDate = new Date(startTimeMs + simDeltaMs);
 
       // Rotate Earth using sidereal time
       const rotAngle = satellite.gstime(simDate)
@@ -238,5 +240,5 @@ export function useSatelliteScene({
         mountNode.removeChild(renderer.domElement);
       }
     };
-  }, [mountRef, timeRef, speedRef, satellites, groundStations]);
+  }, [mountRef, timeRef, speedRef, satellites, groundStations, startTimeMs]);
 }


### PR DESCRIPTION
## Summary
- allow configuring simulation start time in sidebar
- plumb start time through app to simulation hook

## Testing
- `npm run lint`
- `npm run build`
