### PR TITLE
Add sidebar file import/export buttons

### DIFF
--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { SatelliteSpec } from "../satellites";
 import type { GroundStation } from "../groundStations";
 import {
@@ -16,6 +16,68 @@ export default function SatelliteEditor({ onUpdate }: Props) {
   const [constText, setConstText] = useState("");
   const [gsText, setGsText] = useState("");
   const [open, setOpen] = useState(false);
+
+  const satInputRef = useRef<HTMLInputElement | null>(null);
+  const constInputRef = useRef<HTMLInputElement | null>(null);
+  const gsInputRef = useRef<HTMLInputElement | null>(null);
+
+  function downloadFile(name: string, text: string) {
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function handleFileLoad<T>(
+    file: File,
+    setter: (t: string) => void,
+    parser: (t: string) => T,
+    validator?: (v: T) => void,
+  ) {
+    const text = await file.text();
+    try {
+      const parsed = parser(text);
+      if (validator) validator(parsed);
+      setter(text);
+    } catch (e) {
+      alert("Invalid file: " + (e as Error).message);
+    }
+  }
+
+  function validateSatellites(list: SatelliteSpec[]) {
+    for (const s of list) {
+      if (s.type === "tle") {
+        if (!s.lines[0] || !s.lines[1]) {
+          throw new Error("satellites.toml: missing TLE lines");
+        }
+      } else if (s.type === "elements") {
+        const e = s.elements;
+        if (
+          e.satnum === undefined ||
+          !(e.epoch instanceof Date) ||
+          Number.isNaN(e.semiMajorAxisKm) ||
+          Number.isNaN(e.eccentricity) ||
+          Number.isNaN(e.inclinationDeg) ||
+          Number.isNaN(e.raanDeg) ||
+          Number.isNaN(e.argPerigeeDeg) ||
+          Number.isNaN(e.meanAnomalyDeg)
+        ) {
+          throw new Error("satellites.toml: incomplete elements entry");
+        }
+      }
+    }
+  }
+
+  function validateGroundStations(list: GroundStation[]) {
+    for (const g of list) {
+      if (!g.name || Number.isNaN(g.latitudeDeg) || Number.isNaN(g.longitudeDeg)) {
+        throw new Error("groundstations.toml: missing required fields");
+      }
+    }
+  }
 
   useEffect(() => {
     fetch("/satellites.toml")
@@ -36,6 +98,8 @@ export default function SatelliteEditor({ onUpdate }: Props) {
       const base = parseSatellitesToml(satText);
       const con = constText ? parseConstellationToml(constText) : [];
       const gs = parseGroundStationsToml(gsText);
+      validateSatellites([...base, ...con]);
+      validateGroundStations(gs);
       onUpdate([...base, ...con], gs);
     } catch (e) {
       alert("Failed to parse files: " + (e as Error).message);
@@ -95,7 +159,32 @@ export default function SatelliteEditor({ onUpdate }: Props) {
           ✕
         </button>
         <div style={{ paddingTop: 24 }}>
-          <div>satellites.toml</div>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <span>satellites.toml</span>
+            <button
+              onClick={() => downloadFile("satellites.toml", satText)}
+              style={{ marginLeft: 4, background: "transparent", border: "none", color: "#fff" }}
+            >
+              💾
+            </button>
+            <button
+              onClick={() => satInputRef.current?.click()}
+              style={{ marginLeft: 4, background: "transparent", border: "none", color: "#fff" }}
+            >
+              📂
+            </button>
+            <input
+              ref={satInputRef}
+              type="file"
+              accept=".toml"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) handleFileLoad(f, setSatText, parseSatellitesToml, validateSatellites);
+                e.target.value = "";
+              }}
+            />
+          </div>
           <textarea
             value={satText}
             onChange={(e) => setSatText(e.target.value)}
@@ -103,7 +192,32 @@ export default function SatelliteEditor({ onUpdate }: Props) {
           />
         </div>
         <div style={{ marginTop: 4 }}>
-          <div>constellation.toml</div>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <span>constellation.toml</span>
+            <button
+              onClick={() => downloadFile("constellation.toml", constText)}
+              style={{ marginLeft: 4, background: "transparent", border: "none", color: "#fff" }}
+            >
+              💾
+            </button>
+            <button
+              onClick={() => constInputRef.current?.click()}
+              style={{ marginLeft: 4, background: "transparent", border: "none", color: "#fff" }}
+            >
+              📂
+            </button>
+            <input
+              ref={constInputRef}
+              type="file"
+              accept=".toml"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) handleFileLoad(f, setConstText, parseConstellationToml, validateSatellites);
+                e.target.value = "";
+              }}
+            />
+          </div>
           <textarea
             value={constText}
             onChange={(e) => setConstText(e.target.value)}
@@ -111,7 +225,32 @@ export default function SatelliteEditor({ onUpdate }: Props) {
           />
         </div>
         <div style={{ marginTop: 4 }}>
-          <div>groundstations.toml</div>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <span>groundstations.toml</span>
+            <button
+              onClick={() => downloadFile("groundstations.toml", gsText)}
+              style={{ marginLeft: 4, background: "transparent", border: "none", color: "#fff" }}
+            >
+              💾
+            </button>
+            <button
+              onClick={() => gsInputRef.current?.click()}
+              style={{ marginLeft: 4, background: "transparent", border: "none", color: "#fff" }}
+            >
+              📂
+            </button>
+            <input
+              ref={gsInputRef}
+              type="file"
+              accept=".toml"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) handleFileLoad(f, setGsText, parseGroundStationsToml, validateGroundStations);
+                e.target.value = "";
+              }}
+            />
+          </div>
           <textarea
             value={gsText}
             onChange={(e) => setGsText(e.target.value)}


### PR DESCRIPTION
## Summary
- enable TOML file download and upload in the sidebar
- validate uploaded TOML files before using them

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
