### PR TITLE
Add satellite metadata display

### DIFF
--- a/scripts/generate-satellites.ts
+++ b/scripts/generate-satellites.ts
@@ -80,11 +80,29 @@ function generateFromShells(con: any): any[] {
 }
 
 const baseSatellites = rawSats.map((s) => {
+  const meta = {
+    objectName: s.name ?? s.OBJECT_NAME,
+    objectId: s.objectId ?? s.OBJECT_ID,
+    noradCatId:
+      s.noradCatId !== undefined && s.noradCatId !== null
+        ? Number(s.noradCatId)
+        : s.NORAD_CAT_ID !== undefined
+          ? Number(s.NORAD_CAT_ID)
+          : undefined,
+  };
+  const metaClean =
+    meta.objectName !== undefined ||
+    meta.objectId !== undefined ||
+    meta.noradCatId !== undefined
+      ? meta
+      : undefined;
   if (s.type === "tle") {
-    return { type: "tle", lines: [s.line1, s.line2] };
+    const obj: any = { type: "tle", lines: [s.line1, s.line2] };
+    if (metaClean) obj.meta = metaClean;
+    return obj;
   }
   if (s.type === "elements") {
-    return {
+    const obj: any = {
       type: "elements",
       elements: {
         satnum: Number(s.satnum),
@@ -97,6 +115,8 @@ const baseSatellites = rawSats.map((s) => {
         meanAnomalyDeg: Number(s.meanAnomalyDeg),
       },
     };
+    if (metaClean) obj.meta = metaClean;
+    return obj;
   }
   throw new Error("Unknown satellite type");
 });

--- a/src/data/satellites.ts
+++ b/src/data/satellites.ts
@@ -19,9 +19,15 @@ export interface OrbitalElements {
   meanAnomalyDeg: number;
 }
 
+export interface SatelliteMetadata {
+  objectName?: string;
+  objectId?: string;
+  noradCatId?: number;
+}
+
 export type SatelliteSpec =
-  | { type: "tle"; lines: [string, string] }
-  | { type: "elements"; elements: OrbitalElements };
+  | { type: "tle"; lines: [string, string]; meta?: SatelliteMetadata }
+  | { type: "elements"; elements: OrbitalElements; meta?: SatelliteMetadata };
 
 /** Convert epoch date to `YYDDD.DDDDDDDD` format used by TLEs. */
 function formatTleEpoch(date: Date): string {

--- a/src/utils/formatSatelliteInfo.ts
+++ b/src/utils/formatSatelliteInfo.ts
@@ -4,11 +4,19 @@ export function formatSatelliteInfo(satellites: SatelliteSpec[], idx: number | n
   if (idx === null) return "";
   const spec = satellites[idx];
   if (!spec) return "";
+  const meta = spec.meta;
+  let metaText = "";
+  if (meta) {
+    if (meta.objectName) metaText += `OBJECT_NAME: ${meta.objectName}\n`;
+    if (meta.objectId) metaText += `OBJECT_ID: ${meta.objectId}\n`;
+    if (meta.noradCatId !== undefined) metaText += `NORAD_CAT_ID: ${meta.noradCatId}\n`;
+  }
   if (spec.type === "tle") {
-    return spec.lines.join("\n");
+    return metaText + spec.lines.join("\n");
   }
   const e = spec.elements;
   return (
+    metaText +
     `satnum: ${e.satnum}\n` +
     `a: ${e.semiMajorAxisKm} km\n` +
     `e: ${e.eccentricity}\n` +

--- a/src/utils/tomlParse.ts
+++ b/src/utils/tomlParse.ts
@@ -32,8 +32,28 @@ export function parseSatellitesToml(text: string): SatelliteSpec[] {
   if (current) result.push(current);
 
   return result.map((s) => {
+    const meta = {
+      objectName: s.name ?? s.OBJECT_NAME,
+      objectId: s.objectId ?? s.OBJECT_ID,
+      noradCatId:
+        s.noradCatId !== undefined && s.noradCatId !== null
+          ? Number(s.noradCatId)
+          : s.NORAD_CAT_ID !== undefined
+            ? Number(s.NORAD_CAT_ID)
+            : undefined,
+    };
+    const metaClean =
+      meta.objectName !== undefined ||
+      meta.objectId !== undefined ||
+      meta.noradCatId !== undefined
+        ? meta
+        : undefined;
     if (s.type === 'tle') {
-      return { type: 'tle', lines: [String(s.line1 || ''), String(s.line2 || '')] } as SatelliteSpec;
+      return {
+        type: 'tle',
+        lines: [String(s.line1 || ''), String(s.line2 || '')],
+        meta: metaClean,
+      } as SatelliteSpec;
     }
     if (s.type === 'elements') {
       return {
@@ -48,6 +68,7 @@ export function parseSatellitesToml(text: string): SatelliteSpec[] {
           argPerigeeDeg: Number(s.argPerigeeDeg),
           meanAnomalyDeg: Number(s.meanAnomalyDeg),
         },
+        meta: metaClean,
       } as SatelliteSpec;
     }
     throw new Error('Unknown satellite type');


### PR DESCRIPTION
## Summary
- add `SatelliteMetadata` interface
- parse metadata from TOML and OMM JSON
- preserve metadata in generated satellites list
- export metadata in satellites.toml
- show satellite metadata in popup

## Testing
- `bun run build`
- `bun run lint`