### PR TITLE
Add clear buttons for TOML editors

### DIFF
--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -341,6 +341,12 @@ export default function SatelliteEditor({ onUpdate }: Props) {
             >
               🌐
             </button>
+            <button
+              onClick={() => setSatText("")}
+              style={{ marginLeft: 0, background: "transparent", border: "none", color: "#fff" }}
+            >
+              🗑️
+            </button>
             <input
               ref={satInputRef}
               type="file"
@@ -374,6 +380,12 @@ export default function SatelliteEditor({ onUpdate }: Props) {
             >
               📂
             </button>
+            <button
+              onClick={() => setConstText("")}
+              style={{ marginLeft: 0, background: "transparent", border: "none", color: "#fff" }}
+            >
+              🗑️
+            </button>
             <input
               ref={constInputRef}
               type="file"
@@ -406,6 +418,12 @@ export default function SatelliteEditor({ onUpdate }: Props) {
               style={{ marginLeft: 0, background: "transparent", border: "none", color: "#fff" }}
             >
               📂
+            </button>
+            <button
+              onClick={() => setGsText("")}
+              style={{ marginLeft: 0, background: "transparent", border: "none", color: "#fff" }}
+            >
+              🗑️
             </button>
             <input
               ref={gsInputRef}


### PR DESCRIPTION
## Summary
- allow clearing the text in `satellites.toml`, `constellation.toml`, and `groundstations.toml`

## Testing
- `npm run lint`
- `npm run build`
