### PR TITLE
Add ground station info bubble

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useSatelliteScene } from "./hooks/useSatelliteScene";
 import { SATELLITES as INITIAL_SATS } from "./data/satellites";
 import { loadGroundStations, type GroundStation } from "./data/groundStations";
 import { formatSatelliteInfo } from "./utils/formatSatelliteInfo";
+import { formatGroundStationInfo } from "./utils/formatGroundStationInfo";
 
 /**
  * Top level React component hosting the visualization. It sets up
@@ -19,10 +20,12 @@ const INITIAL_SPEED = 60; // initial 60× real time
 function App() {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const timeRef = useRef<HTMLDivElement | null>(null);
+  const gsInfoRef = useRef<HTMLPreElement | null>(null);
 
   const [satellites, setSatellites] = useState(INITIAL_SATS);
   const [groundStations, setGroundStations] = useState<GroundStation[]>([]);
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const [selectedGsIdx, setSelectedGsIdx] = useState<number | null>(null);
 
   const [satRadius, setSatRadius] = useState(() =>
     window.innerWidth <= 600 ? 0.02 : 0.015,
@@ -53,9 +56,12 @@ function App() {
     groundStations,
     satRadius,
     onSelect: setSelectedIdx,
+    onSelectStation: setSelectedGsIdx,
+    stationInfoRef: gsInfoRef,
   });
 
   const infoText = formatSatelliteInfo(satellites, selectedIdx);
+  const gsInfoText = formatGroundStationInfo(groundStations, selectedGsIdx);
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -91,6 +97,25 @@ function App() {
           }}
         >
           {infoText}
+        </pre>
+      )}
+      {gsInfoText && (
+        <pre
+          ref={gsInfoRef}
+          style={{
+            position: "fixed",
+            left: 0,
+            top: 0,
+            transform: "translate(-50%, -100%)",
+            color: "#fff",
+            fontFamily: "'Noto Sans Mono', monospace",
+            fontSize: "0.9rem",
+            pointerEvents: "none",
+            whiteSpace: "pre",
+            zIndex: 10,
+          }}
+        >
+          {gsInfoText}
         </pre>
       )}
       <SpeedControl value={speedExp} onChange={setSpeedExp} />

--- a/src/utils/formatGroundStationInfo.ts
+++ b/src/utils/formatGroundStationInfo.ts
@@ -1,0 +1,18 @@
+import type { GroundStation } from '../data/groundStations';
+
+/**
+ * Build a human readable block of text describing the ground station at the
+ * provided index. Returns an empty string when no station is selected.
+ */
+export function formatGroundStationInfo(stations: GroundStation[], idx: number | null): string {
+  if (idx === null) return '';
+  const gs = stations[idx];
+  if (!gs) return '';
+  return (
+    `name: ${gs.name}\n` +
+    `lat: ${gs.latitudeDeg} deg\n` +
+    `lon: ${gs.longitudeDeg} deg\n` +
+    `height: ${gs.heightKm} km\n` +
+    `minEl: ${gs.minElevationDeg} deg`
+  );
+}


### PR DESCRIPTION
## Summary
- show ground station info when clicking a station
- compute bubble position each frame and display near the station

## Testing
- `bun run lint`
- `bun run build`
