### PR TITLE
Implement visibility report generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "prebuild": "bun scripts/generate-satellites.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "report": "bun scripts/generate-visibility-report.ts"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/scripts/generate-visibility-report.ts
+++ b/scripts/generate-visibility-report.ts
@@ -1,0 +1,40 @@
+import { parseSatellitesToml, parseConstellationToml, parseGroundStationsToml } from "../src/utils/tomlParse";
+import { generateVisibilityReport } from "../src/utils/visibilityReport";
+
+function preprocessToml(text: string): string {
+  return text.replace(
+    /(epoch\s*=\s*)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/,
+    (_, p1, p2) => `${p1}"${p2}"`,
+  );
+}
+
+async function main() {
+  const startArg = Bun.argv[2];
+  const stepArg = Bun.argv[3];
+  const startTime = startArg ? new Date(startArg) : new Date();
+  const stepMinutes = stepArg ? Number(stepArg) : 10;
+
+  const satText = await Bun.file("public/satellites.toml").text();
+  let satellites = parseSatellitesToml(satText);
+
+  try {
+    const constRaw = await Bun.file("public/constellation.toml").text();
+    const constText = preprocessToml(constRaw);
+    satellites = satellites.concat(parseConstellationToml(constText));
+  } catch {
+    /* no constellation file */
+  }
+
+  const gsText = await Bun.file("public/groundstations.toml").text();
+  const groundStations = parseGroundStationsToml(gsText);
+
+  const report = generateVisibilityReport(satellites, groundStations, startTime, 15, stepMinutes);
+
+  await Bun.write("visibility-report.json", JSON.stringify(report, null, 2));
+  console.log("Report written to visibility-report.json");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/utils/visibilityReport.ts
+++ b/src/utils/visibilityReport.ts
@@ -1,0 +1,77 @@
+import * as satellite from "satellite.js";
+import { toSatrec, type SatelliteSpec } from "../data/satellites";
+import type { GroundStation } from "../data/groundStations";
+
+export interface VisibilityRecord {
+  time: string;
+  count: number;
+  satellites: string[];
+}
+
+export interface VisibilityReport {
+  startTime: string;
+  stepMinutes: number;
+  days: number;
+  stations: string[];
+  records: Record<string, VisibilityRecord[]>;
+}
+
+function satName(spec: SatelliteSpec, idx: number): string {
+  return (
+    spec.meta?.objectName ??
+    spec.meta?.objectId ??
+    (spec.meta?.noradCatId !== undefined ? String(spec.meta.noradCatId) : `sat-${idx}`)
+  );
+}
+
+export function generateVisibilityReport(
+  satellites: SatelliteSpec[],
+  groundStations: GroundStation[],
+  startTime: Date,
+  days = 15,
+  stepMinutes = 10,
+): VisibilityReport {
+  const satRecs = satellites.map((s) => toSatrec(s));
+  const observerGds = groundStations.map((gs) => ({
+    longitude: satellite.degreesToRadians(gs.longitudeDeg),
+    latitude: satellite.degreesToRadians(gs.latitudeDeg),
+    height: gs.heightKm,
+  }));
+  const minElRads = groundStations.map((gs) => satellite.degreesToRadians(gs.minElevationDeg));
+  const endTime = new Date(startTime.getTime() + days * 24 * 60 * 60 * 1000);
+  const records: Record<string, VisibilityRecord[]> = {};
+  groundStations.forEach((gs) => {
+    records[gs.name] = [];
+  });
+  for (let t = startTime.getTime(); t <= endTime.getTime(); t += stepMinutes * 60000) {
+    const current = new Date(t);
+    const gmst = satellite.gstime(current);
+    const satPos = satRecs.map((rec) => {
+      const result = satellite.propagate(rec, current);
+      return result ? result.position : null;
+    });
+    const satEcfs = satPos.map((pos) => (pos ? satellite.eciToEcf(pos, gmst) : null));
+    groundStations.forEach((gs, gi) => {
+      const visible: string[] = [];
+      satEcfs.forEach((ecf, si) => {
+        if (!ecf) return;
+        const look = satellite.ecfToLookAngles(observerGds[gi], ecf);
+        if (look.elevation > minElRads[gi]) {
+          visible.push(satName(satellites[si], si));
+        }
+      });
+      records[gs.name].push({
+        time: current.toISOString(),
+        count: visible.length,
+        satellites: visible,
+      });
+    });
+  }
+  return {
+    startTime: startTime.toISOString(),
+    stepMinutes,
+    days,
+    stations: groundStations.map((gs) => gs.name),
+    records,
+  };
+}


### PR DESCRIPTION
## Summary
- add visibility report calculation utilities
- implement `generate-visibility-report.ts` script
- expose new `report` npm script in `package.json`
- fix null check in visibility report

## Testing
- `bun run lint`
- `npm run build`
- `bun run report 2025-05-20T00:00:00Z 60`
