### PR TITLE
Add ecliptic and sun direction toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,8 @@ function App() {
 
   const [earthTexture, setEarthTexture] = useState("/assets/earth01.webp");
   const [showGraticule, setShowGraticule] = useState(true);
+  const [showEcliptic, setShowEcliptic] = useState(true);
+  const [showSunDirection, setShowSunDirection] = useState(true);
 
   const [startTime, setStartTime] = useState(() => {
     const d = new Date();
@@ -59,6 +61,8 @@ function App() {
     satRadius,
     earthTexture,
     showGraticule,
+    showEcliptic,
+    showSunDirection,
     onSelect: setSelectedIdx,
     onSelectStation: setSelectedGsIdx,
     stationInfoRef: gsInfoRef,
@@ -130,6 +134,10 @@ function App() {
         onEarthTextureChange={setEarthTexture}
         showGraticule={showGraticule}
         onShowGraticuleChange={setShowGraticule}
+        showEcliptic={showEcliptic}
+        onShowEclipticChange={setShowEcliptic}
+        showSunDirection={showSunDirection}
+        onShowSunDirectionChange={setShowSunDirection}
         onUpdate={(s, gs, start) => {
           setSatellites(s);
           setGroundStations(gs);

--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -136,6 +136,14 @@ interface Props {
   showGraticule: boolean;
   /** Called when graticule visibility changes */
   onShowGraticuleChange: (v: boolean) => void;
+  /** Show or hide ecliptic plane */
+  showEcliptic: boolean;
+  /** Called when ecliptic visibility changes */
+  onShowEclipticChange: (v: boolean) => void;
+  /** Show or hide sun direction marker */
+  showSunDirection: boolean;
+  /** Called when sun direction visibility changes */
+  onShowSunDirectionChange: (v: boolean) => void;
 }
 
 export default function SatelliteEditor({
@@ -146,6 +154,10 @@ export default function SatelliteEditor({
   onEarthTextureChange,
   showGraticule,
   onShowGraticuleChange,
+  showEcliptic,
+  onShowEclipticChange,
+  showSunDirection,
+  onShowSunDirectionChange,
 }: Props) {
   const [satText, setSatText] = useState("");
   const [constText, setConstText] = useState("");
@@ -592,6 +604,28 @@ export default function SatelliteEditor({
                     onChange={(e) => onShowGraticuleChange(e.target.checked)}
                   />
                   <span style={{ marginLeft: 4 }}>Show latitude/longitude lines</span>
+                </label>
+              </div>
+              <div style={{ marginTop: 4 }}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={showEcliptic}
+                    onChange={(e) => onShowEclipticChange(e.target.checked)}
+                  />
+                  <span style={{ marginLeft: 4 }}>Show ecliptic plane</span>
+                </label>
+              </div>
+              <div style={{ marginTop: 4 }}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={showSunDirection}
+                    onChange={(e) =>
+                      onShowSunDirectionChange(e.target.checked)
+                    }
+                  />
+                  <span style={{ marginLeft: 4 }}>Show sun direction</span>
                 </label>
               </div>
               <hr style={{ marginTop: 12, marginBottom: 12 }} />

--- a/src/hooks/useSatelliteScene.ts
+++ b/src/hooks/useSatelliteScene.ts
@@ -25,6 +25,10 @@ interface Params {
   satRadius: number;
   earthTexture: string;
   showGraticule: boolean;
+  /** Show or hide ecliptic plane line */
+  showEcliptic: boolean;
+  /** Show or hide sun direction marker */
+  showSunDirection: boolean;
   onSelect?: (idx: number | null) => void;
   onSelectStation?: (idx: number | null) => void;
   stationInfoRef?: React.RefObject<HTMLPreElement | null>;
@@ -45,6 +49,8 @@ export function useSatelliteScene({
   satRadius,
   earthTexture,
   showGraticule,
+  showEcliptic,
+  showSunDirection,
   onSelect,
   onSelectStation,
   stationInfoRef,
@@ -94,12 +100,14 @@ export function useSatelliteScene({
     scene.add(graticule);
 
     const ecliptic = createEclipticLine(1);
+    ecliptic.visible = showEcliptic;
     scene.add(ecliptic);
 
     // Small marker for the sun position
     const sunDotGeo = new THREE.SphereGeometry(0.01, 8, 8);
     const sunDotMat = new THREE.MeshBasicMaterial({ color: 0xffff00 });
     const sunDot = new THREE.Mesh(sunDotGeo, sunDotMat);
+    sunDot.visible = showSunDirection;
     scene.add(sunDot);
 
     // Geometries for satellites, their subpoints and ground stations
@@ -378,6 +386,8 @@ export function useSatelliteScene({
     satRadius,
     earthTexture,
     showGraticule,
+    showEcliptic,
+    showSunDirection,
     onSelect,
     onSelectStation,
     stationInfoRef,


### PR DESCRIPTION
## Summary
- expose visibility toggles for ecliptic line and sun marker in the UI
- connect the new settings through the React component tree
- show/hide the ecliptic and sun marker in the Three.js scene

## Testing
- `npm run lint`
- `npm run build`
