### PR TITLE
Add ECEF camera mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ function App() {
   const [showGraticule, setShowGraticule] = useState(true);
   const [showEcliptic, setShowEcliptic] = useState(true);
   const [showSunDirection, setShowSunDirection] = useState(true);
+  const [ecef, setEcef] = useState(false);
 
   const [startTime, setStartTime] = useState(() => {
     const d = new Date();
@@ -63,6 +64,7 @@ function App() {
     showGraticule,
     showEcliptic,
     showSunDirection,
+    ecef,
     onSelect: setSelectedIdx,
     onSelectStation: setSelectedGsIdx,
     stationInfoRef: gsInfoRef,
@@ -138,6 +140,8 @@ function App() {
         onShowEclipticChange={setShowEcliptic}
         showSunDirection={showSunDirection}
         onShowSunDirectionChange={setShowSunDirection}
+        ecef={ecef}
+        onEcefChange={setEcef}
         onUpdate={(s, gs, start) => {
           setSatellites(s);
           setGroundStations(gs);

--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -144,6 +144,10 @@ interface Props {
   showSunDirection: boolean;
   /** Called when sun direction visibility changes */
   onShowSunDirectionChange: (v: boolean) => void;
+  /** Display scene in Earth-fixed (ECEF) mode */
+  ecef: boolean;
+  /** Called when ECEF mode changes */
+  onEcefChange: (v: boolean) => void;
 }
 
 export default function SatelliteEditor({
@@ -158,6 +162,8 @@ export default function SatelliteEditor({
   onShowEclipticChange,
   showSunDirection,
   onShowSunDirectionChange,
+  ecef,
+  onEcefChange,
 }: Props) {
   const [satText, setSatText] = useState("");
   const [constText, setConstText] = useState("");
@@ -638,6 +644,16 @@ export default function SatelliteEditor({
                     }}
                   />
                   <span style={{ marginLeft: 4 }}>Show ecliptic plane</span>
+                </label>
+              </div>
+              <div style={{ marginTop: 4 }}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={ecef}
+                    onChange={(e) => onEcefChange(e.target.checked)}
+                  />
+                  <span style={{ marginLeft: 4 }}>ECEF mode</span>
                 </label>
               </div>
               <hr style={{ marginTop: 12, marginBottom: 12 }} />

--- a/src/hooks/useSatelliteScene.ts
+++ b/src/hooks/useSatelliteScene.ts
@@ -27,6 +27,7 @@ export function useSatelliteScene(params: SatelliteSceneParams) {
     params.showGraticule,
     params.showEcliptic,
     params.showSunDirection,
+    params.ecef,
     params.onSelect,
     params.onSelectStation,
     params.stationInfoRef,

--- a/src/scene/SatelliteScene.ts
+++ b/src/scene/SatelliteScene.ts
@@ -30,6 +30,8 @@ export interface SatelliteSceneParams {
   showGraticule: boolean;
   showEcliptic: boolean;
   showSunDirection: boolean;
+  /** Rotate the camera with the Earth to approximate an ECEF view */
+  ecef: boolean;
   onSelect?: (idx: number | null) => void;
   onSelectStation?: (idx: number | null) => void;
   stationInfoRef?: React.RefObject<HTMLPreElement | null>;
@@ -40,6 +42,7 @@ export default class SatelliteScene {
   private readonly camera: THREE.PerspectiveCamera;
   private readonly renderer: THREE.WebGLRenderer;
   private readonly controls: OrbitControls;
+  private readonly cameraHolder: THREE.Group;
   private readonly disposeFns: (() => void)[] = [];
 
   private readonly satRecs: satellite.SatRec[];
@@ -84,6 +87,9 @@ export default class SatelliteScene {
       1000,
     );
     this.camera.position.set(0, 0, 3);
+    this.cameraHolder = new THREE.Group();
+    this.cameraHolder.add(this.camera);
+    this.scene.add(this.cameraHolder);
 
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
     this.renderer.setSize(window.innerWidth, window.innerHeight);
@@ -306,6 +312,7 @@ export default class SatelliteScene {
     const rotAngle = satellite.gstime(simDate);
     this.earthMesh.rotation.y = rotAngle;
     this.graticule.rotation.y = rotAngle;
+    this.cameraHolder.rotation.y = this.params.ecef ? rotAngle : 0;
 
     const { x: sx, y: sy, z: sz } = sunVectorECI(simDate);
     this.sunlight.position.set(sx * 10, sz * 10, -sy * 10);


### PR DESCRIPTION
## Summary
- add ECEF toggle to sidebar options
- rotate camera holder with Earth when ECEF is on
- wire up new option through App and scene hook

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683cf9d2cf708328abe6739402b1a20d