### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.x"
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+        env:
+          BASE_URL: /constellation-vis/
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
@@ -15,6 +15,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/SatelliteEditor.tsx
+++ b/src/components/SatelliteEditor.tsx
@@ -282,14 +282,14 @@ export default function SatelliteEditor({
 
 
   useEffect(() => {
-    fetch("/satellites.toml")
+    fetch(import.meta.env.BASE_URL + 'satellites.toml')
       .then((r) => r.text())
       .then(setSatText);
-    fetch("/constellation.toml")
+    fetch(import.meta.env.BASE_URL + 'constellation.toml')
       .then((r) => r.text())
       .then(setConstText)
       .catch(() => setConstText(""));
-    fetch("/groundstations.toml")
+    fetch(import.meta.env.BASE_URL + 'groundstations.toml')
       .then((r) => r.text())
       .then(setGsText)
       .catch(() => setGsText(""));

--- a/src/data/groundStations.ts
+++ b/src/data/groundStations.ts
@@ -3,7 +3,7 @@ import { parseGroundStationsToml, type GroundStation } from '../utils/tomlParse'
 // Helper used by the demo to fetch and parse the bundled ground station list.
 
 export async function loadGroundStations(): Promise<GroundStation[]> {
-  const resp = await fetch('/groundstations.toml');
+  const resp = await fetch(import.meta.env.BASE_URL + 'groundstations.toml');
   const text = await resp.text();
   return parseGroundStationsToml(text);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
+const base = (globalThis as any).process?.env?.BASE_URL || '/constellation-vis/';
+
 export default defineConfig({
   plugins: [react()],
+  base,
 })


### PR DESCRIPTION
## Summary
- set Vite base path for GitHub Pages
- fix absolute paths in index.html
- fetch bundled toml files via `import.meta.env.BASE_URL`
- add GitHub Actions workflow to deploy to GitHub Pages

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6842c072e6e883288eea49c90a4f5cad